### PR TITLE
Wrap single-result result sets in an array

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,7 +13,7 @@ def results(query)
   if search['total_results'].to_i == 0
     []
   else
-    search.results.work
+    [search.results.work].flatten
   end
 end
 


### PR DESCRIPTION
For whatever reason, either the Goodreads API can return a single result, or the Ruby gem(s) involved are parsing it wrong.